### PR TITLE
Backwards incompatible changes for 1.0:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+**/.DS_Store
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
+--format progress
 --color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: ruby
 env:
-  - CODECLIMATE_REPO_TOKEN=703cb4759e977bdd9502305ae454a0acdf7bd0d51d418e88048110f4735c4a80
+  global:
+    - CODECLIMATE_REPO_TOKEN=703cb4759e977bdd9502305ae454a0acdf7bd0d51d418e88048110f4735c4a80
 rvm:
-  - 2.2.3
-  - 2.3.0
-script: "bundle exec rspec"
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - bundle exec rspec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 notifications:
   email:
     recipients:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/require_dir.svg)](https://badge.fury.io/rb/require_dir)
 [![Downloads](http://ruby-gem-downloads-badge.herokuapp.com/require_dir?type=total)](https://rubygems.org/gems/require_dir)
 
-<br />
-
 [![Build Status](https://travis-ci.org/kigster/require_dir.svg?branch=master)](https://travis-ci.org/kigster/warp-dir)
 [![Code Climate](https://codeclimate.com/github/kigster/require_dir/badges/gpa.svg)](https://codeclimate.com/githb/kigster/require_dir)
 [![Test Coverage](https://codeclimate.com/github/kigster/require_dir/badges/coverage.svg)](https://codeclimate.com/github/kigster/require_dir/coverage)
@@ -17,7 +15,7 @@ Unlike other gems, such as `require_all`, this gem does suffer from module clobb
 
 ## Author
 
-This library is the work of [Konstantin Gredeskoul](http:/kig.re), &copy; 2016, distributed under the MIT license.
+This library is the work of [Konstantin Gredeskoul](http:/kig.re), &copy; 2016-2018, distributed under the MIT license.
 
 ## Installation
 
@@ -43,14 +41,16 @@ Recommended usage is to include this gem's module into the top level module of y
 # file 'lib/mylib.rb' -- top level file for a gem 'mylib'
 require 'require_dir'
 module Mylib
-  extend RequireDir
-  init __FILE__
+  RequireDir.enable_require_dir!(self, __FILE__)
 end
 
-Mylib.dir('mylib/subfolder')   # loads all files in the folder 'lib/mylib/subfolder/*.rb'
-Mylib.dir_r('mylib/subfolder') # recursive load from 'lib/mylib/subfolder/**/*.rb'
+Mylib.require_dir('mylib/subfolder')   # loads all files in the folder 'lib/mylib/subfolder/*.rb'
+Mylib.require_dir_r('mylib/subfolder') # recursive load from 'lib/mylib/subfolder/**/*.rb'
 
 ```
+
+You can also use shorcuts `dir` and `dir_r`, which are equivalent to `require_dir` and  `require_dir_r` respectively.
+
 
 ### Offset
 
@@ -66,8 +66,7 @@ be able to later use RequireDir to load files relative to `lib`. This is how you
 require 'require_dir'
 module Mylib
   module SubFolder
-    extend RequireDir
-    init_with_offset(__FILE__, 1)
+    RequireDir.enable_require_dir!(self, __FILE__, 1)
   end
 end
 
@@ -86,8 +85,7 @@ exploded. You can enable debugging output using two methods:
  * Initialize library with options hash, setting:
 
 ```ruby
-  extend RequireDir
-  init __FILE__, debug: true
+  RequireDir.enable_require_dir!(self, __FILE__, 0, debug: true)
 ```
 
 ## Development

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,35 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'yard'
+
+def shell(*args)
+  puts "running: #{args.join(' ')}"
+  system(args.join(' '))
+end
+
+task :clean do 
+  shell('rm -rf pkg/ tmp/ coverage/ doc/' )
+end
+
+task :gem => [:build] do
+  shell('gem install pkg/*')
+end
+
+task :permissions => [ :clean ] do 
+  shell("chmod -v o+r,g+r * */* */*/* */*/*/* */*/*/*/* */*/*/*/*/*")
+  shell("find . -type d -exec chmod o+x,g+x {} \\;")
+end
+
+task :build => :permissions
+
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.files = %w(lib/**/*.rb exe/*.rb - README.md LICENSE.txt)
+  t.options.unshift('--title','RequireDir')
+  t.after = ->() { exec('open doc/index.html') }
+end
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+

--- a/lib/require_dir/initializer.rb
+++ b/lib/require_dir/initializer.rb
@@ -1,0 +1,32 @@
+require 'forwardable'
+module RequireDir
+  module Initializer
+    attr_accessor :loader
+    class << self
+      def included(base)
+        base.instance_eval do
+          class << self
+            attr_accessor :loader
+            extend Forwardable
+            def_delegators :@loader, :dir, :dir_r, :require_dir, :require_dir_r
+          end
+        end
+      end
+    end
+
+    def init(source, offset = 0, options = {})
+      project_folder = project_folder_from(source: source, offset: offset)
+      self.loader    = create_loader(options, project_folder)
+    end
+
+    def create_loader(options, project_folder)
+      RequireDir::Loader.new(project_folder, options)
+    end
+
+    def project_folder_from(source:, offset: 0)
+      dirs_up = ''
+      offset.times { dirs_up << '/..' } if offset > 0
+      File.dirname(File.expand_path(source + dirs_up))
+    end
+  end
+end

--- a/lib/require_dir/version.rb
+++ b/lib/require_dir/version.rb
@@ -1,3 +1,3 @@
 module RequireDir
-  VERSION = '0.1.2'
+  VERSION = '1.0.0'
 end

--- a/require_dir.gemspec
+++ b/require_dir.gemspec
@@ -17,8 +17,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = %w(lib)
 
+  spec.add_dependency 'colored2'
+
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.5' 
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/loader/loader-error/bad.rb
+++ b/spec/loader/loader-error/bad.rb
@@ -1,0 +1,5 @@
+puts "HELOO"
+raise StandardError, 'FUCK!'
+klass MooHahah
+  end
+end

--- a/spec/require_dir_spec.rb
+++ b/spec/require_dir_spec.rb
@@ -2,11 +2,23 @@ require 'spec_helper'
 
 describe RequireDir do
   module TestModule
-    extend RequireDir
+    RequireDir.enable_require_dir!(self, __FILE__)
   end
 
   it 'has a version number' do
     expect(RequireDir::VERSION).not_to be nil
+  end
+
+  context 'deprecated usage' do
+    before do
+      TestModule.instance_eval do
+        include RequireDir
+        init(__FILE__)
+      end
+    end
+    it 'still works despite deprecation' do
+      expect(TestModule).to respond_to(:init)
+    end
   end
 
   context '#project_folder_from' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'require_dir'
+require 'rspec'
+require 'simplecov'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+SimpleCov.start
+
+require 'require_dir'


### PR DESCRIPTION
- removing the need to include the RequireDir module
- instead using enable method